### PR TITLE
feat: Add optional debugContext field

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker run -it -p 3001:3001 \
 
 - `POST /issues` → Create a new GitHub issue
   - **Required:** `title`, `contactName`, `contactEmail`, `description`, `environment`, `expectedBehavior`, `actualBehavior`, `reproducibility`
-  - **Optional:** `attachments[]` (array of URLs)
+  - **Optional:** `attachments[]` (array of URLs), `debugContext` (URL/context of the page the report was filed from)
 
 ### 📣 Complaints
 

--- a/src/controllers/issues.controller.js
+++ b/src/controllers/issues.controller.js
@@ -9,8 +9,19 @@ import { maskEmail } from '../utils/maskEmail.js';
  */
 export async function createIssue(request, reply) {
   try {
-    const { title, contactName, contactEmail, description, environment, expectedBehavior, actualBehavior, reproducibility, attachments, debug } =
-      request.body;
+    const {
+      title,
+      contactName,
+      contactEmail,
+      description,
+      environment,
+      debugContext,
+      expectedBehavior,
+      actualBehavior,
+      reproducibility,
+      attachments,
+      debug,
+    } = request.body;
 
     if (debug === true) {
       request.log.info('Debug mode: returning fake GitHub issue data');
@@ -44,7 +55,7 @@ export async function createIssue(request, reply) {
     }
 
     // Create the body for the GitHub issue
-    const body = `## Contact Information\n**Contact Name:** ${contactName}\n**Contact Email:** ${maskedEmail}\n\n## Issue Details\n**Description:** \n${description}\n\n**Environment:** ${environment}\n\n**Expected Behavior:** \n${expectedBehavior}\n\n**Actual Behavior:** \n${actualBehavior}\n\n**Reproducibility:** ${reproducibility}\n\n${attachments && attachments.length > 0 ? `## Attachments\n${attachments.map((url) => `- ${url}`).join('\n')}` : ''}\n\n---\n*Issue created via API on ${new Date().toISOString()}*`;
+    const body = `## Contact Information\n**Contact Name:** ${contactName}\n**Contact Email:** ${maskedEmail}\n\n## Issue Details\n**Description:** \n${description}\n\n**Environment:** ${environment}\n\n**Expected Behavior:** \n${expectedBehavior}\n\n**Actual Behavior:** \n${actualBehavior}\n\n**Reproducibility:** ${reproducibility}\n${debugContext ? `\n\n**Debug Context:** ${debugContext}` : ''}\n\n${attachments && attachments.length > 0 ? `## Attachments\n${attachments.map((url) => `- ${url}`).join('\n')}` : ''}\n\n---\n*Issue created via API on ${new Date().toISOString()}*`;
     const labels = ['REPORTED-BY-USER'];
     // Create the GitHub issue
     const response = await ky.post(`https://api.github.com/repos/${repoOwner}/${repoName}/issues`, {

--- a/src/schemas/issues.schema.js
+++ b/src/schemas/issues.schema.js
@@ -29,6 +29,7 @@ export const createIssueSchema = {
     .prop('contactEmail', S.string().format('email').description('Email of the person reporting the issue'))
     .prop('description', S.string().minLength(10).maxLength(5000).description('Detailed description of the issue'))
     .prop('environment', S.string().minLength(1).maxLength(200).description('Environment where the issue occurred'))
+    .prop('debugContext', S.string().maxLength(2000).description('Optional debug context URL, e.g. the page the user was on when reporting'))
     .prop('expectedBehavior', S.string().minLength(5).maxLength(1000).description('What was expected to happen'))
     .prop('actualBehavior', S.string().minLength(5).maxLength(1000).description('What actually happened'))
     .prop('reproducibility', S.string().enum(['always', 'sometimes', 'rarely', 'once']).description('How often the issue can be reproduced'))

--- a/tests/issues.test.js
+++ b/tests/issues.test.js
@@ -94,9 +94,24 @@ describe('createIssue', () => {
     expect(options.headers['Content-Type']).to.equal('application/json');
   });
 
+  it('should include debug context in the GitHub issue body when provided', async () => {
+    request.body.debugContext = 'https://example.com/some-page';
+
+    const mockResponse = createMockGitHubResponse(1, 'Test Issue');
+
+    post.resolves(mockResponse);
+
+    await createIssue(request, reply);
+
+    const [, options] = post.firstCall.args;
+
+    expect(options.json.body).to.include('**Debug Context:** https://example.com/some-page');
+  });
+
   it('should work with missing optional fields', async () => {
     request.body.attachments = undefined;
     request.body.environment = undefined;
+    request.body.debugContext = undefined;
     request.body.expectedBehavior = undefined;
     request.body.actualBehavior = undefined;
     request.body.reproducibility = undefined;


### PR DESCRIPTION
In continue to the frontend change:
https://github.com/hasadna/open-bus-map-search/pull/1764/

I would like to add the link that tells where the user comes from and the main search parameters to allow easier debug.
it is optional as some pages comes without context (main page and such).

First time contributing to this repo- I'm not sure if the order front/back matters as it is an optional field. If it does, please let me know. Also, not really know how to test this other then npm test :)